### PR TITLE
Py deps

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -54,7 +54,6 @@ pyramid_tm = 0.7
 PyYAML = 3.10
 repoze.lru = 0.6
 simplejson = 3.1.0
-six = 1.3.0
 SQLAlchemy = 0.7.10
 transaction = 1.4.1
 translationstring = 1.1

--- a/scripts/upload-to-s3.py
+++ b/scripts/upload-to-s3.py
@@ -25,7 +25,6 @@ def get_env():
 def upload(data_file, stagging='dev'):
 
     conn =  S3Connection(config.get('Credentials','aws_access_key_id'), config.get('Credentials','aws_secret_key'))
-    
     bucket = conn.get_bucket('mf-aap')
     bucket.configure_versioning(True)
     k = Key(bucket)
@@ -34,7 +33,7 @@ def upload(data_file, stagging='dev'):
 
 
 
-    with open(data_file) as file:  
+    with open(data_file) as file:
         data = file.read()
         k.set_contents_from_string(data)
 


### PR DESCRIPTION
six 1.3 is not a requirement and contradicts other minimal version requirements.